### PR TITLE
Updates to build on Rolling

### DIFF
--- a/ros2/CMakeLists.txt
+++ b/ros2/CMakeLists.txt
@@ -14,7 +14,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_action
 )
 
-if(BUILD_EXAMPLE)
 add_executable(bt_executable
     examples/fibonacci_bt.cpp
 )
@@ -36,7 +35,6 @@ install(
   RUNTIME DESTINATION
     lib/${PROJECT_NAME}
 )
-endif()
 
 install(
   DIRECTORY include/

--- a/ros2/CMakeLists.txt
+++ b/ros2/CMakeLists.txt
@@ -20,7 +20,6 @@ add_executable(bt_executable
 target_include_directories(bt_executable PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_compile_features(bt_executable PUBLIC cxx_std_20)
 ament_target_dependencies(bt_executable
   PUBLIC
     ${THIS_PACKAGE_INCLUDE_DEPENDS}


### PR DESCRIPTION
- Remove the C++20 specification in CMakeLists
- Remove the BUILD_EXAMPLE flag. I don't think this is a great idea, anyway -- what if several projects had BUILD_EXAMPLE?